### PR TITLE
Each of the scenes is available to run independently now

### DIFF
--- a/Assets/Audio/demo0.mp3.meta
+++ b/Assets/Audio/demo0.mp3.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 13be73aa66651ff488283bfe0a9585af
+timeCreated: 1474311971
+licenseType: Free
+AudioImporter:
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/demo1.mp3.meta
+++ b/Assets/Audio/demo1.mp3.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 09e9c25d4bcbc41478adea9e9fd51718
+timeCreated: 1474311970
+licenseType: Free
+AudioImporter:
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/NetworkMapTest.unity
+++ b/Assets/Scenes/NetworkMapTest.unity
@@ -7876,6 +7876,48 @@ Transform:
   m_PrefabParentObject: {fileID: 4000010023993874, guid: 9002b5fe5836a984190617783897d6b8,
     type: 2}
   m_PrefabInternal: {fileID: 26265718}
+--- !u!1001 &2126301450
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4000014049288254, guid: a0254a0ee9db37b488e060239f75ad4e, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014049288254, guid: a0254a0ee9db37b488e060239f75ad4e, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014049288254, guid: a0254a0ee9db37b488e060239f75ad4e, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014049288254, guid: a0254a0ee9db37b488e060239f75ad4e, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014049288254, guid: a0254a0ee9db37b488e060239f75ad4e, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014049288254, guid: a0254a0ee9db37b488e060239f75ad4e, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014049288254, guid: a0254a0ee9db37b488e060239f75ad4e, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014049288254, guid: a0254a0ee9db37b488e060239f75ad4e, type: 2}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: a0254a0ee9db37b488e060239f75ad4e, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &2133745481
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NetworkManager.cs
+++ b/Assets/Scripts/NetworkManager.cs
@@ -7,22 +7,29 @@ public class NetworkManager : Photon.PunBehaviour
     public static NetworkManager Instance = null;
 
     // Use this for initialization
-    void Awake()
+    void Start()
 	{
         if (Instance == null)
         {
             Instance = this;
             Object.DontDestroyOnLoad(this);
             PhotonNetwork.automaticallySyncScene = true;
-            PhotonNetwork.ConnectUsingSettings(GameConstants.VERSION_STRING);
+            if (!SceneManager.GetSceneByName("StartMenu").isLoaded)
+            {
+                PhotonNetwork.offlineMode = true;
+                PhotonNetwork.CreateRoom("OfflineRoom");
+            }
+            else
+            {
+                PhotonNetwork.ConnectUsingSettings(GameConstants.VERSION_STRING);
+            }
+        }
+        else
+        {
+            Destroy(gameObject);
         }
 	}
 	
-	// Update is called once per frame
-	void Update ()
-	{
-	}
-
     public void CreateAndJoinGameSession(string sessionName)
     {
         if (!PhotonNetwork.insideLobby)
@@ -40,10 +47,5 @@ public class NetworkManager : Photon.PunBehaviour
     public void JoinGameSession(string sessionName)
     {
         PhotonNetwork.JoinRoom(sessionName);
-    }
-
-    public override void OnJoinedRoom()
-    {
-        PhotonNetwork.LoadLevel("Scenes/CharacterSelect");
     }
 }

--- a/Assets/Scripts/StartMenuManager.cs
+++ b/Assets/Scripts/StartMenuManager.cs
@@ -1,18 +1,8 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-public class StartMenuManager : MonoBehaviour
+public class StartMenuManager : Photon.PunBehaviour 
 {
-    // Use this for initialization
-    void Start ()
-	{
-	}
-	
-	// Update is called once per frame
-	void Update ()
-	{
-	}
-
     void OnGUI()
     {
         GUILayout.Label(PhotonNetwork.connectionStateDetailed.ToString());
@@ -25,5 +15,10 @@ public class StartMenuManager : MonoBehaviour
         {
             NetworkManager.Instance.JoinGameSession("Default Session");
         }
+    }
+
+    public override void OnJoinedRoom()
+    {
+        PhotonNetwork.LoadLevel("Scenes/CharacterSelect");
     }
 }

--- a/Assets/Sprites/Column_01_v02.png.meta
+++ b/Assets/Sprites/Column_01_v02.png.meta
@@ -1,0 +1,59 @@
+fileFormatVersion: 2
+guid: 9f9ba8cb26d2ae24083d71a95494f84d
+timeCreated: 1474311967
+licenseType: Free
+TextureImporter:
+  fileIDToRecycleName: {}
+  serializedVersion: 2
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    linearTexture: 0
+    correctGamma: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 0
+  cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
+  seamlessCubemap: 0
+  textureFormat: -1
+  maxTextureSize: 2048
+  textureSettings:
+    filterMode: -1
+    aniso: 16
+    mipBias: -1
+    wrapMode: 1
+  nPOTScale: 0
+  lightmap: 0
+  rGBM: 0
+  compressionQuality: 50
+  allowsAlphaSplitting: 0
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spritePixelsToUnits: 100
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  buildTargetSettings: []
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Flipping the photon network into offline if we don't start on the
start menu scene.

Accomplished this by...

Making the network manager a universal object so that it can set
the photon network to offline mode based on the starting scene.

Put a check in the CharacterSelectManager and if the network is
in offline mode then we have to manually call the player properties
callback to register turning the ready flag off and on