### PR TITLE
Fixed the weird collisions with the bridge

### DIFF
--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -2614,11 +2614,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 4000011810478156, guid: c124c13890f7bed479375b4726278e5b, type: 2}
       propertyPath: m_LocalPosition.x
-      value: -1.48
+      value: -1.52
       objectReference: {fileID: 0}
     - target: {fileID: 4000011810478156, guid: c124c13890f7bed479375b4726278e5b, type: 2}
       propertyPath: m_LocalPosition.y
-      value: -1.45
+      value: -1.96
       objectReference: {fileID: 0}
     - target: {fileID: 4000011810478156, guid: c124c13890f7bed479375b4726278e5b, type: 2}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scripts/SimplePhysics.cs
+++ b/Assets/Scripts/SimplePhysics.cs
@@ -265,13 +265,14 @@ namespace Filibusters
         {
             if (other.layer == mTwoWay)
             {
-                float scale = Mathf.Abs(other.transform.localScale.y);
                 BoxCollider2D bCol = other.GetComponent<BoxCollider2D>();
-                float size = bCol.size.y / 2f * scale;
-                float offset = bCol.offset.y * scale;
+                float size = bCol.size.y / 2f;
+                float offset = bCol.offset.y;
 
                 // Get the top position of the box collider
-                float top = other.transform.position.y + size + offset;
+                Vector3 localPos = other.transform.localPosition;
+                float topOfsInWorldCoords = other.transform.TransformVector(new Vector3(localPos.x, size + offset)).y;
+                float top = other.transform.position.y + topOfsInWorldCoords;
                 return top >= mPrevY || mPressedDown;
             }
             return false;


### PR DESCRIPTION
Issue: Players would occassionally collide with the bridge
in the MainGame scene.

Why did it happen: It was happening because the offset for the
top of the collider in ShouldPassThrough was not being computed
correctly due to an error in localScale. localScale only refers to
the scale in relation to the immediate parent, but not any scale
that might exist above that.

The fix: Using Transform.TransformVector properly transformed the
offset vector into worldspace
was used