### PR TITLE
fixes #441

### DIFF
--- a/Assets/Scripts/DynamicUIInputAxis.cs
+++ b/Assets/Scripts/DynamicUIInputAxis.cs
@@ -41,13 +41,11 @@ namespace Filibusters
 
             if (!anyJoysticksConnected && (joystickWasConnected || mFirstFrame))
             {
-                EventSystem.OnInputSourceUpdated();
                 mUIEventSystem.SetSelectedGameObject(null);
                 joystickWasConnected = false;
             }
             else if (anyJoysticksConnected && !joystickWasConnected )
             {
-                EventSystem.OnInputSourceUpdated();
                 mUIEventSystem.SetSelectedGameObject(mUIEventSystem.firstSelectedGameObject);
                 joystickWasConnected = true;
             }

--- a/Assets/Scripts/EventSystem.cs
+++ b/Assets/Scripts/EventSystem.cs
@@ -153,15 +153,5 @@ namespace Filibusters
                 OnDepositEndEvent();
             }
         }
-
-        public delegate void InputSourceUpdatedListener();
-        public static event InputSourceUpdatedListener OnInputSourceUpdatedEvent;
-        public static void OnInputSourceUpdated()
-        {
-            if (OnInputSourceUpdatedEvent != null)
-            {
-                OnInputSourceUpdatedEvent();
-            }
-        }
     }
 }

--- a/Assets/Scripts/SessionInputHandler.cs
+++ b/Assets/Scripts/SessionInputHandler.cs
@@ -2,6 +2,7 @@
 using UnityEngine.UI;
 
 using System.Collections.Generic;
+using System.Collections;
 
 namespace Filibusters
 {
@@ -9,8 +10,6 @@ namespace Filibusters
     {
         InputField mSessionNameField;
         ErrorToast mErrorToaster;
-
-        bool mInputChangeTrigger = false;
 
         private static readonly Dictionary<int, string> ErrorCodeMap = new Dictionary<int, string>()
         {
@@ -26,12 +25,6 @@ namespace Filibusters
             mSessionNameField.onValidateInput += delegate(string input, int charIndex, char addedChar) { return ValidateChar(addedChar); };
             mSessionNameField.onEndEdit.AddListener(delegate { OnHostGameNameEntered(); });
             mErrorToaster = GetComponent<ErrorToast>();
-            EventSystem.OnInputSourceUpdatedEvent += IgnoreInputChangeSignal;
-        }
-
-        void IgnoreInputChangeSignal()
-        {
-            mInputChangeTrigger = true;
         }
 
         char ValidateChar(char newChar)
@@ -45,10 +38,8 @@ namespace Filibusters
 
         public void OnHostGameNameEntered()
         {
-            // Ignore the false EndEdit signal triggered when a input source changes
-            if (mInputChangeTrigger)
+            if (!InputWrapper.Instance.SubmitPressed)
             {
-                mInputChangeTrigger = false;
                 return;
             }
 


### PR DESCRIPTION
my old method for filtering out non-submit end-edits for the input
field was convoluted and ultimately didn't work. This was because when
the dynamic ui input system was initially deselecting the event systems
first selected object in mouse mode it was triggering the OnEndEdit
callback which was causing all kinds of problems. Now we just check if
submit was pressed anytime the OnEndEdit callback is called and if it
wasn't we return early