### PR TITLE
Fix two way platform glitch

### DIFF
--- a/Assets/Prefabs/Small Desk.prefab
+++ b/Assets/Prefabs/Small Desk.prefab
@@ -21,7 +21,7 @@ GameObject:
   - 4: {fileID: 4000013387490130}
   - 212: {fileID: 212000012500276966}
   - 61: {fileID: 61000012746755102}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Small Desk
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -35,7 +35,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012592712726}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3.4500008, y: -0.96000004, z: 0}
+  m_LocalPosition: {x: 3.15, y: -7.31, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
@@ -47,14 +47,14 @@ BoxCollider2D:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012592712726}
-  m_Enabled: 0
+  m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_Offset: {x: -0.07160747, y: -0.005114794}
+  m_Offset: {x: -0.07160807, y: 0.024737358}
   serializedVersion: 2
-  m_Size: {x: 1.3143859, y: 1.1738002}
+  m_Size: {x: 1.3143859, y: 1.1140964}
 --- !u!212 &212000012500276966
 SpriteRenderer:
   m_ObjectHideFlags: 1
@@ -86,5 +86,5 @@ SpriteRenderer:
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 50aac53495db4db4fa15532d995a7ee0, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 1
+  m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -23223,7 +23223,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 114911542}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -8.624621, y: -10.52, z: 0}
+  m_LocalPosition: {x: -8.624621, y: -10.522951, z: 0}
   m_LocalScale: {x: 2.065408, y: 0.1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
@@ -23465,25 +23465,6 @@ Prefab:
     - target: {fileID: 1000012592712726, guid: e60e72c8eb1ae41659cdd4c19fe67ff7, type: 2}
       propertyPath: m_Name
       value: Small Desk Right
-      objectReference: {fileID: 0}
-    - target: {fileID: 212000012500276966, guid: e60e72c8eb1ae41659cdd4c19fe67ff7,
-        type: 2}
-      propertyPath: m_FlipX
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 212000012500276966, guid: e60e72c8eb1ae41659cdd4c19fe67ff7,
-        type: 2}
-      propertyPath: m_SortingLayerID
-      value: 1661287921
-      objectReference: {fileID: 0}
-    - target: {fileID: 61000012746755102, guid: e60e72c8eb1ae41659cdd4c19fe67ff7,
-        type: 2}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1000012592712726, guid: e60e72c8eb1ae41659cdd4c19fe67ff7, type: 2}
-      propertyPath: m_Layer
-      value: 11
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: e60e72c8eb1ae41659cdd4c19fe67ff7, type: 2}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/14002413/20128207/26740cfa-a60c-11e6-8f02-27ba58dcbd8c.png)

I raised the box collider bottom for this object. 
The bottom of the collider was going through the floor. 
The player's raycasts were interacting with this and dropping the player slightly below the floor.
This was causing the player for fall through two of the two way platforms.