### PR TITLE
Now we can hear other players firing their guns

### DIFF
--- a/Assets/Photon/Photon Unity Networking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/Photon Unity Networking/Resources/PhotonServerSettings.asset
@@ -59,4 +59,6 @@ MonoBehaviour:
   - IncrementReadyCount
   - ToggleActive
   - OnDamaged
+  - FireRPC
+  - MisfireRPC
   DisableAutoOpenWizard: 1

--- a/Assets/Scenes/ReadyScreen.unity
+++ b/Assets/Scenes/ReadyScreen.unity
@@ -928,6 +928,16 @@ Prefab:
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114000012889001894, guid: fb202c0e4daa57e47a02a85da90ea96e,
+        type: 2}
+      propertyPath: viewIdField
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012889001894, guid: fb202c0e4daa57e47a02a85da90ea96e,
+        type: 2}
+      propertyPath: instantiationId
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: fb202c0e4daa57e47a02a85da90ea96e, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -7,6 +7,8 @@ namespace Filibusters
 {
     public class AudioManager : MonoBehaviour
     {
+        enum PhotonEvents { FIRE_EVT = 0 };
+
         public static AudioManager Instance = null;
         private AudioSource mSource;
 
@@ -142,59 +144,42 @@ namespace Filibusters
                 }
             };
 
-            EventSystem.OnWeaponFiredEvent += (int actorId, WeaponId weaponId) =>
+            EventSystem.OnWeaponFiredEvent += (WeaponId weaponId) =>
             {
-                if (actorId == PhotonNetwork.player.ID)
-                {
-                    AudioClip clip = null;
-                    float volume = 1.0f;
-                    switch (weaponId)
-                    {
-                        case WeaponId.DARK_HORSE:
-                            clip = mUseDarkhorse;
-                            break;
-                        case WeaponId.VETO:
-                            clip = mUseVeto;
-                            volume = 0.5f;
-                            break;
-                        case WeaponId.MAGIC_BULLET:
-                            clip = mUseMagicBullet;
-                            break;
-                        case WeaponId.ANARCHY:
-                            clip = mUseAnarchy;
-                            break;
-                        case WeaponId.LIBEL_AND_SLANDER:
-                            clip = mUseLibelAndSlander;
-                            break;
-                    }
-                    mSource.PlayOneShot(clip, volume);
-                }
+                PhotonNetwork.RaiseEvent((byte)PhotonEvents.FIRE_EVT, weaponId, false, null);
+                WeaponFireCallback(weaponId);
             };
 
-            EventSystem.OnWeaponMisfiredEvent += (int actorId, GameConstants.WeaponId weaponId) =>
+            EventSystem.OnWeaponMisfiredEvent += (WeaponId weaponId) =>
             {
-                if (actorId == PhotonNetwork.player.ID)
+                AudioClip misfire = null;
+                switch (weaponId)
                 {
-                    AudioClip misfire = null;
-                    switch (weaponId)
-                    {
-                        case WeaponId.DARK_HORSE:
-                            misfire = mMisfireDarkhorse;
-                            break;
-                        case WeaponId.VETO:
-                            misfire = mMisfireVeto;
-                            break;
-                        case WeaponId.MAGIC_BULLET:
-                            misfire = mMisfireMagicBullet;
-                            break;
-                        case WeaponId.ANARCHY:
-                            misfire = mMisfireAnarchy;
-                            break;
-                        case WeaponId.LIBEL_AND_SLANDER:
-                            misfire = mMisfireLibelAndSlander;
-                            break;
-                    }
-                    mSource.PlayOneShot(misfire);
+                    case WeaponId.DARK_HORSE:
+                        misfire = mMisfireDarkhorse;
+                        break;
+                    case WeaponId.VETO:
+                        misfire = mMisfireVeto;
+                        break;
+                    case WeaponId.MAGIC_BULLET:
+                        misfire = mMisfireMagicBullet;
+                        break;
+                    case WeaponId.ANARCHY:
+                        misfire = mMisfireAnarchy;
+                        break;
+                    case WeaponId.LIBEL_AND_SLANDER:
+                        misfire = mMisfireLibelAndSlander;
+                        break;
+                }
+                mSource.PlayOneShot(misfire);
+            };
+
+            PhotonNetwork.OnEventCall += (byte evtCode, object contents, int senderId) =>
+            {
+                var weaponId = (WeaponId)contents;
+                if ((PhotonEvents)evtCode == PhotonEvents.FIRE_EVT)
+                {
+                    WeaponFireCallback(weaponId);
                 }
             };
 
@@ -215,6 +200,32 @@ namespace Filibusters
                 }
                 mSource.PlayOneShot(grunt);
             };
+        }
+
+        void WeaponFireCallback(WeaponId weaponId)
+        {
+            AudioClip clip = null;
+            float volume = 1.0f;
+            switch (weaponId)
+            {
+                case WeaponId.DARK_HORSE:
+                    clip = mUseDarkhorse;
+                    break;
+                case WeaponId.VETO:
+                    clip = mUseVeto;
+                    volume = 0.5f;
+                    break;
+                case WeaponId.MAGIC_BULLET:
+                    clip = mUseMagicBullet;
+                    break;
+                case WeaponId.ANARCHY:
+                    clip = mUseAnarchy;
+                    break;
+                case WeaponId.LIBEL_AND_SLANDER:
+                    clip = mUseLibelAndSlander;
+                    break;
+            }
+            mSource.PlayOneShot(clip, volume);
         }
     }
 }

--- a/Assets/Scripts/EventSystem.cs
+++ b/Assets/Scripts/EventSystem.cs
@@ -74,23 +74,23 @@ namespace Filibusters
             }
         }
 
-        public delegate void WeaponFireListener(int actorId, GameConstants.WeaponId weaponId);
+        public delegate void WeaponFireListener(GameConstants.WeaponId weaponId);
         public static event WeaponFireListener OnWeaponFiredEvent;
-        public static void OnWeaponFired(int actorId, GameConstants.WeaponId weaponId)
+        public static void OnWeaponFired(GameConstants.WeaponId weaponId)
         {
             if (OnWeaponFiredEvent != null)
             {
-                OnWeaponFiredEvent(actorId, weaponId);
+                OnWeaponFiredEvent(weaponId);
             }
         }
 
-        public delegate void WeaponMisfireListener(int actorId, GameConstants.WeaponId weaponId);
+        public delegate void WeaponMisfireListener(GameConstants.WeaponId weaponId);
         public static event WeaponMisfireListener OnWeaponMisfiredEvent;
-        public static void OnWeaponMisfired(int actorId, GameConstants.WeaponId weaponId)
+        public static void OnWeaponMisfired(GameConstants.WeaponId weaponId)
         {
             if (OnWeaponMisfiredEvent != null)
             {
-                OnWeaponMisfiredEvent(actorId, weaponId);
+                OnWeaponMisfiredEvent(weaponId);
             }
         }
 

--- a/Assets/Scripts/PlayerAttack.cs
+++ b/Assets/Scripts/PlayerAttack.cs
@@ -25,12 +25,10 @@ namespace Filibusters
         private LayerMask mWeaponClippingCheck;
 
         private WeaponInventory mWeaponInventory;
-        private int mActorId;
 
         void Start()
         {
             mWeaponInventory = GetComponent<WeaponInventory>();
-            mActorId = GetComponent<PhotonView>().owner.ID;
         }
 
         void Update()
@@ -56,12 +54,12 @@ namespace Filibusters
                             GameObject go = PhotonNetwork.Instantiate(projectile.fx, xform.position, Quaternion.identity, 0);
                             go.transform.parent = gameObject.transform;
                         }
-                        EventSystem.OnWeaponFired(mActorId, weaponId);
+                        EventSystem.OnWeaponFired(weaponId);
                     }
                     // Weapon is out of ammo
                     else
                     {
-                        EventSystem.OnWeaponMisfired(mActorId, weaponId);
+                        EventSystem.OnWeaponMisfired(weaponId);
                     }
                 }
             }


### PR DESCRIPTION
Implemented using Photon Event Raising as opposed to RPC because
RPC requires a photon view and there is a major issue with using
photon views on objects that exist on multiple different scenes
and are singletons

opted against doing this for misfire