### PR TITLE
Lock room when game starts so no extra players can join

### DIFF
--- a/Assets/Scripts/ReadyScreenNetworkController.cs
+++ b/Assets/Scripts/ReadyScreenNetworkController.cs
@@ -135,13 +135,15 @@ namespace Filibusters
 
         public void StartGame()
         {
-            GetComponent<PhotonView>().RPC("LaunchGame", PhotonTargets.All);
+            GetComponent<PhotonView>().RPC("LaunchGame", PhotonTargets.MasterClient);
         }
 
         [PunRPC]
         public void LaunchGame()
         {
             PhotonNetwork.LoadLevel(Scenes.MAIN);
+            PhotonNetwork.room.visible = false;
+            PhotonNetwork.room.open = false;
         }
     }
 }

--- a/Assets/Scripts/SessionInputHandler.cs
+++ b/Assets/Scripts/SessionInputHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Photon;
 using UnityEngine.UI;
+using UnityEngine.SceneManagement;
 
 using System.Collections.Generic;
 using System.Collections;
@@ -62,7 +63,7 @@ namespace Filibusters
 
         public override void OnJoinedRoom()
         {
-            PhotonNetwork.LoadLevel(Scenes.READY_SCREEN);
+            SceneManager.LoadScene(Scenes.READY_SCREEN);
         }
 
         public override void OnPhotonCreateRoomFailed(object[] codeAndMsg)


### PR DESCRIPTION
The root of our previous issues with locking and making the room invisible was that I was incorrectly having EVERY client call PhotonNetwork.LoadLevel was is setup to make every other client also load the same level. Basically because multiple clients were calling LoadLevel, some clients would load the level multiple times creating ghost characters